### PR TITLE
V0.0.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2025] [Anmol Anand]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cron-automate",
+  "name": "oneoff-automate",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cron-automate",
+      "name": "oneoff-automate",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cron-automate",
+  "name": "oneoff-automate",
   "version": "0.0.1",
   "description": "A NPM Package to Automate CronJob.",
   "keywords": [

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -8,7 +8,8 @@
       "name": "test",
       "version": "1.0.0",
       "dependencies": {
-        "cron-automate": "file:../packs/cron-automate-0.0.1.tgz"
+        "cron-automate": "file:../packs/cron-automate-0.0.1.tgz",
+        "oneoff-automate": "file:../packs/oneoff-automate-0.0.1.tgz"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -102,6 +103,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/oneoff-automate": {
+      "version": "0.0.1",
+      "resolved": "file:../packs/oneoff-automate-0.0.1.tgz",
+      "integrity": "sha512-3PsnJsf3MmyH3DAOU4CBYasCTXWWt44pw8iKFvYouljKJ3D6HQVOfQUuQDCytp9dyd2RVNjal85QRc6geAGFVg==",
+      "license": "MIT",
+      "dependencies": {
+        "ioredis": "^5.7.0"
+      }
     },
     "node_modules/redis-errors": {
       "version": "1.2.0",

--- a/test/package.json
+++ b/test/package.json
@@ -10,6 +10,7 @@
   "author": "anmol420",
   "type": "module",
   "dependencies": {
-    "cron-automate": "file:../packs/cron-automate-0.0.1.tgz"
+    "cron-automate": "file:../packs/cron-automate-0.0.1.tgz",
+    "oneoff-automate": "file:../packs/oneoff-automate-0.0.1.tgz"
   }
 }


### PR DESCRIPTION
This pull request introduces a new package called `oneoff-automate`, updates package references to reflect this addition, and adds a license file. The most important changes are grouped below:

**Licensing:**
* Added a new `LICENSE` file with the MIT License for the project.

**Package introduction and dependency updates:**
* Renamed the main package in `package.json` from `cron-automate` to `oneoff-automate`.
* Added `oneoff-automate` as a dependency in `test/package.json` alongside the existing `cron-automate` package.
* Updated `test/package-lock.json` to include `oneoff-automate` as a dependency and added its lockfile entry, specifying its version, integrity, and dependencies. 